### PR TITLE
Document default Basic bundle in tutorial

### DIFF
--- a/src/tutorial/new-dist.pod
+++ b/src/tutorial/new-dist.pod
@@ -11,7 +11,7 @@ to do I<much> more than just build a bunch of files for you to edit.
 For the tasks below, you'll want to:
 
 =for :list
-* install L<Dist::Zilla>, version 4.101780 or later
+* install L<Dist::Zilla>, version 4.102342 or later
 * run C<L<dzil setup|@initial-setup>>
 
 The rest of this document assumes that you haven't made a custom minting
@@ -25,7 +25,7 @@ work.
 It's easy:
 
   $ dzil new Your::Library
-  [DZ] making directory ./Your-Library
+  [DZ] making target dir ./Your-Library
   [DZ] writing files to /Users/rjbs/tmp/Your-Library
   [DZ] dist minted in ./Your-Library
 
@@ -40,6 +40,10 @@ F<./Your-Library/dist.ini>:
   copyright_holder = E. Xavier Ample <example@cpan.org>
   copyright_year   = 2010
 
+  version = 0.001
+
+  [@Basic]
+
 F<./Your-Library/lib/Your/Library.pm>
 
   #!perl
@@ -51,8 +55,10 @@ F<./Your-Library/lib/Your/Library.pm>
 
 There isn't a lot of other boilerplate, because the default minter assumes that
 you're going to go whole hog and use lots of plugins to build everything else
-you might need.  (It doesn't I<add> those plugins to your F<dist.ini> for you,
-though.  You'll have to do that yourself.)
+you might need. It doesn't I<add> those plugins to your F<dist.ini> for you,
+though. The only plugins it I<does> add are the ones in the
+L<Basic bundle|Dist::Zilla::PluginBundle::Basic>, so that the other C<dzil>
+commands work. You'll have choose the other plugins yourself.
 
 =head2 Write some code and some tests
 
@@ -71,3 +77,4 @@ release!
 ? versioning   ? learn about managing version numbers with Dist::Zilla
 ? release      ? learn how to release your distribution to the CPAN
 ? minting-profile ? learn how to customize the minting process
+? how-build-works ? learn about plugins and Dist::Zilla's build phases


### PR DESCRIPTION
As we briefly discussed on IRC earlier today:

This change brings the tutorial in line with the behavior of `dzil new` in 4.102342, especially the part where it now adds a [@Basic] line to the default dist.ini .

Please note that the machine I'm on does not have perl 5.12, so I have only run my change through podchecker and pod2html, not the actual script used to build the pages for dzil.org .

Please let me know if you think this can be improved.
