### PR TITLE
Point links to metacpan.org

### DIFF
--- a/src/tutorial/build-tutorial.pod
+++ b/src/tutorial/build-tutorial.pod
@@ -214,6 +214,7 @@ sub pod_to_html {
   $parser->html_h_level(3);
   $parser->html_header('');
   $parser->html_footer('');
+  $parser->perldoc_url_prefix("https://metacpan.org/module");
   $parser->parse_string_document( Encode::encode('utf-8', $pod) );
 
   $html = "<div class='pod'>$html</div>";


### PR DESCRIPTION
Hi Ricardo,
I was reading up on the excellent Dist::Zilla module management software and found myself all of a sudden on search.cpan.org all the time where I missed all the good stuff that has been added on metacpan.org.

The accompanied perldoc_url_postfix setting for Pod::PseudoPod::HTML makes CPAN links point to metacpan.

Thanks for the excellent D::Z software!
## 

Mike
