### PR TITLE
Fix tiny typo in tutorial/minting-profile.pod

### DIFF
--- a/src/tutorial/minting-profile.pod
+++ b/src/tutorial/minting-profile.pod
@@ -1,4 +1,3 @@
-
 =head1 Customizing the Minting Process
 
 Dist::Zilla lets you create any number of "minting profiles" to create
@@ -124,7 +123,7 @@ work for just about everything.
 
 First, make a new distribution, with a module in it named
 Dist::Zilla::MintingProfile::I<ProviderNameHere> -- replacing ProviderNameHere
-with a name for your provider.  A provider is a module that can provide mintinf
+with a name for your provider.  A provider is a module that can provide minting
 profiles.  Here, it's just there to get a File::ShareDir slot, so it doesn't
 need much code.  This should do it:
 


### PR DESCRIPTION
Hope this helps.

(And Github++ for making it so easy to submit tiny patches like this.)
