### PR TITLE
fixed some bugs in the examples in writing-plugins.pod

### DIFF
--- a/src/tutorial/writing-plugins.pod
+++ b/src/tutorial/writing-plugins.pod
@@ -159,14 +159,12 @@ distribution, so we can just make a simple test like this:
     {
       add_files => {
         'source/dist.ini' => simple_ini(
-          # by default, the sample distribution's dist.ini file inherits 
-          # the parent module's dist.ini.
-          # this hashref can override them, if desired
-          # configs likename, author, license, etc.
+          # By default, source/dist.ini inherits the parent module's dist.ini.
+          # This hashref can override them, if desired.
           {
             # author => "Some Other Author",
           },
-          # subsequent parameters define imported plugins,
+          # Subsequent arguments define imported plugins:
           # [GatherDir] 
           'GatherDir',
           # [Credits]


### PR DESCRIPTION
Hello,
I noticed some bugs while reading through the writing plugins tutorial.  The one in Dist::Zilla::Plugin::Credits was clearly a typo, and I'm guessing the credits.t bug was version skew.  I also found the stuff about corpus/ directory structure a little confusing so I made it explicit by adding a file list.
Cheers, 
Tom Nishimura
