### PR TITLE
Remove CriticTest reference

### DIFF
--- a/src/tutorial/convert-dist.pod
+++ b/src/tutorial/convert-dist.pod
@@ -179,7 +179,7 @@ all the plugin configuration (except for Prereqs) with this:
 
   [PodSyntaxTests]
   [PodCoverageTests]
-  [CriticTests]
+  [Test::Perl::Critic]
 
 ...so we're finally getting back to a nice, small config file.
 


### PR DESCRIPTION
Changed [CriticTests] reference in example to [Test::Perl::Critic]
