### PR TITLE
Document clarification: References are not allowed as default values

### DIFF
--- a/src/tutorial/writing-plugins.pod
+++ b/src/tutorial/writing-plugins.pod
@@ -93,7 +93,7 @@ C<mvp_multivalue_args>.
 
   has filename => (is => 'ro', isa => 'Str', default => 'CREDITS');
 
-  has thank => (is => 'ro', isa => 'ArrayRef[Str]', default => []);
+  has thank => (is => 'ro', isa => 'ArrayRef[Str]', default => sub{[]});
 
   sub mvp_multivalue_args { return qw(thank) }
 


### PR DESCRIPTION
References are not allowed as default values, you must wrap the default of <some attribute> in a CODE reference (ex: sub { [] } and not [])
