### PR TITLE
Added link to the CPAN META file specification

### DIFF
--- a/src/tutorial/prereq.pod
+++ b/src/tutorial/prereq.pod
@@ -41,7 +41,7 @@ probably be simpler to use all around.
 
 In general, the only prereq plugins you should need are RuntimeRequires (the
 default), TestRequires, ConfigureRequires, and BuildRequires.  For more
-information about these, consult the CPAN META file specification.
+information about these, consult L<the CPAN META file specification|https://metacpan.org/pod/CPAN::Meta::Spec>.
 
 =head2 Detecting Your Prereqs
 


### PR DESCRIPTION
I was reading the part on prereqs and had to dig up the link to the specification, so this patch activates it as a link to the specification on MetaCPAN.

jonasbn