### PR TITLE
Reference Dist::Zilla::Starter and @Starter

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -46,6 +46,7 @@
       <li><a href='http://github.com/rjbs/dist-zilla/'>Dist::Zilla on GitHub</a></li>
       <li><a name='mailing-list' />there is a mailing list; you can <a href='http://www.listbox.com/subscribe/?list_id=139292'>join</a> or just read <a href='http://listbox.com/member/archive/139292'>the archives</a></li>
       <li>the <tt>#distzilla</tt> channel on <tt>irc.perl.org</tt></li>
+      <li><a href='https://metacpan.org/pod/Dist::Zilla::Starter'>Dist::Zilla::Starter</a>, a guide to the inner workings of Dist::Zilla and the <a href='https://metacpan.org/pod/Dist::Zilla::PluginBundle::Starter'>@Starter</a> bundle</li>
     </ul>
 
     <div>


### PR DESCRIPTION
I believe the Starter guide and bundle effectively promote responsible and modern dzil usage, and so should be suggested more officially and visibly. This is a bold assertion on my part but please advise whether or how it should be done.