### PR TITLE
Link to web client for IRC channel

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -45,7 +45,7 @@
       <li><a href='tutorial/articles.html'>External articles</a></li>
       <li><a href='http://github.com/rjbs/dist-zilla/'>Dist::Zilla on GitHub</a></li>
       <li><a name='mailing-list' />there is a mailing list; you can <a href='http://www.listbox.com/subscribe/?list_id=139292'>join</a> or just read <a href='http://listbox.com/member/archive/139292'>the archives</a></li>
-      <li>the <tt>#distzilla</tt> channel on <tt>irc.perl.org</tt></li>
+      <li>the <a href='https://kiwiirc.com/client/irc.perl.org/distzilla'>#distzilla</a> channel on <a href='https://www.irc.perl.org'>irc.perl.org</a></li>
     </ul>
 
     <div>


### PR DESCRIPTION
It would promote the visibility and usability of the IRC channel to provide a direct way to join.